### PR TITLE
Deserializer to return proto message object, not generic object.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "optionalDependencies": {
     "whatwg-fetch": "^2.0.3"
   },
-  "main": "./src/index-node.js",
+  "main": "./src/index.js",
   "browser": "./dist/main.js",
   "repository": "https://github.com/thechriswalker/twirp-js",
   "author": "Chris Walker",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const serialize = function (msg) { return msg.serializeBinary(); };
 const deserialize = function (responseType) {
     return function (res) {
         return res.arrayBuffer().then(function (buf) {
-            return responseType.deserializeBinary(new Uint8Array(buf)).toObject();
+            return responseType.deserializeBinary(new Uint8Array(buf));
         });
     };
 };


### PR DESCRIPTION
As per title. When calling a service method, you need to send a request message, and then expect a response message, not a generic object.